### PR TITLE
chore: bump release version to 0.1.32

### DIFF
--- a/apps/OpenComputerUseSmokeSuite/Sources/OpenComputerUseSmokeSuite/main.swift
+++ b/apps/OpenComputerUseSmokeSuite/Sources/OpenComputerUseSmokeSuite/main.swift
@@ -35,7 +35,7 @@ final class MCPClient {
         _ = try request(method: "initialize", params: [
             "clientInfo": [
                 "name": "OpenComputerUseSmokeSuite",
-                "version": "0.1.30",
+                "version": "0.1.32",
             ],
             "capabilities": [:],
             "protocolVersion": "2025-03-26",

--- a/docs/histories/2026-04/20260422-1759-bump-open-computer-use-to-0.1.32.md
+++ b/docs/histories/2026-04/20260422-1759-bump-open-computer-use-to-0.1.32.md
@@ -1,0 +1,30 @@
+## [2026-04-22 17:59] | Task: bump open-computer-use to 0.1.32
+
+### Execution Context
+* **Agent ID**: `Codex`
+* **Base Model**: `GPT-5`
+* **Runtime**: `local macOS shell`
+
+### User Query
+> bump a new version
+
+### Changes Overview
+**Scope:** release version sources, feature release notes, task history
+
+**Key Actions:**
+- **[Version bump]**: 将 Open Computer Use 的主版本源和相关测试/文档示例统一从 `0.1.30` bump 到 `0.1.32`。
+- **[Release record repair]**: 补齐 `0.1.31` 的 feature release note，并新增 `0.1.32` 的版本对齐记录。
+- **[Version-line decision]**: 先核实远端已经存在 `v0.1.31` tag 和 GitHub Release，因此这轮不复用 `0.1.31`，直接顺延到 `0.1.32`，避免继续扩大版本源不一致。
+
+### Design Intent
+这轮的关键不是再发明新的版本规则，而是把仓库重新拉回“单一版本源”状态。当前 `HEAD` 已经对应远端 `v0.1.31`，但仓库里的 manifest 和版本常量仍停在 `0.1.30`；如果继续沿用 `0.1.31`，后续 tag、staging 产物和用户看到的版本号仍然容易打架。顺延到 `0.1.32` 可以在不改写既有 release 的前提下，把当前主线重新收口到一致的版本线。
+
+### Files Modified
+- `plugins/open-computer-use/.codex-plugin/plugin.json`
+- `packages/OpenComputerUseKit/Sources/OpenComputerUseKit/OpenComputerUseVersion.swift`
+- `apps/OpenComputerUseSmokeSuite/Sources/OpenComputerUseSmokeSuite/main.swift`
+- `packages/OpenComputerUseKit/Tests/OpenComputerUseKitTests/OpenComputerUseKitTests.swift`
+- `scripts/computer-use-cli/main.go`
+- `scripts/computer-use-cli/README.md`
+- `docs/releases/feature-release-notes.md`
+- `docs/histories/2026-04/20260422-1759-bump-open-computer-use-to-0.1.32.md`

--- a/docs/releases/feature-release-notes.md
+++ b/docs/releases/feature-release-notes.md
@@ -4,6 +4,8 @@
 
 | 日期 | 功能域 | 用户价值 | 变更摘要 |
 | --- | --- | --- | --- |
+| 2026-04-22 | 发布版本重新对齐 | GitHub Release tag、插件 manifest 和仓库内版本常量重新回到同一个版本线；后续本地安装、staging 和诊断不会再出现 “release 已是新版本，但产物仍显示旧值” 的混乱状态。 | 发布 `0.1.32`，在远端 `v0.1.31` 已存在的前提下，将 `plugin.json`、Swift 版本常量、smoke/test 初始化请求和 CLI helper 文档统一 bump 到 `0.1.32`，为下一次 release 保持单一版本源。 |
+| 2026-04-22 | 视觉光标落点与空闲态收口 | Retina 窗口里的坐标点击更准确，visual cursor 在等待下一次动作时也更稳定、更接近官方观感。 | 发布 `0.1.31`，修复 screenshot pixel 到 window point 的映射，避免 `click({x,y})` 在高分屏上点偏；同时把 idle cursor 收敛为 30 秒停驻、保持压在目标窗口之上，并将等待态改成 anchored tip + tiny rotate wobble。 |
 | 2026-04-22 | Windows runtime 预览与发版说明 | Windows 用户和后续开发者现在有了实验性 Computer Use runtime 起点；每次 GitHub Release 也会保留面向用户的变更摘要，不再只留下 changelog 链接。 | 发布 `0.1.30`，新增实验性 Go/PowerShell Windows runtime、构建脚本和文档；同时明确 release agent 在 bump 版本后必须检查 GitHub 自动 release notes，必要时手动补 `What's Changed`。 |
 | 2026-04-22 | click 定向 fallback | 当目标 app 的 Accessibility 点击链路不完整时，`click` 现在会先尝试定向发送鼠标事件，不会立刻抢走用户真实鼠标；Finder 侧边栏这类场景也更容易真正点通。 | 发布 `0.1.29`，补上 `click` 的 `AX -> pid-targeted mouse event -> optional global pointer fallback` 顺序，优先尝试 `AXPress` / `AXConfirm` / `AXOpen`、子孙点击候选和命中点附近 hit-test，再把全局物理指针保持为显式 opt-in 的最后兜底。 |
 | 2026-04-22 | 软件光标移动速度 | `click` / `set_value` 的 overlay cursor 默认移动速度不再显得过快，和 `Cursor Motion` 默认档及官方 spring endpoint-lock 时间保持一致。 | 发布 `0.1.28`，移除 runtime 里旧的距离压缩时长公式，默认 move 直接使用已恢复出的 `response=1.4` / `dampingFraction=0.9` / `dt=1/240` close-enough 时间 `343 / 240 = 1.4291667s`，并补回归测试和逆向文档。 |

--- a/packages/OpenComputerUseKit/Sources/OpenComputerUseKit/OpenComputerUseVersion.swift
+++ b/packages/OpenComputerUseKit/Sources/OpenComputerUseKit/OpenComputerUseVersion.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public let openComputerUseVersion = "0.1.30"
+public let openComputerUseVersion = "0.1.32"
 
 public func resolvedOpenComputerUseVersion(bundle: Bundle = .main) -> String {
     if let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,

--- a/packages/OpenComputerUseKit/Tests/OpenComputerUseKitTests/OpenComputerUseKitTests.swift
+++ b/packages/OpenComputerUseKit/Tests/OpenComputerUseKitTests/OpenComputerUseKitTests.swift
@@ -325,7 +325,7 @@ final class OpenComputerUseKitTests: XCTestCase {
 
     func testInitializeResponseContainsToolsCapability() throws {
         let server = StdioMCPServer(service: ComputerUseService())
-        let response = server.handle(line: #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"test","version":"0.1.30"},"capabilities":{}}}"#)
+        let response = server.handle(line: #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"test","version":"0.1.32"},"capabilities":{}}}"#)
         XCTAssertNotNil(response)
         XCTAssertTrue(response!.contains(#""name":"open-computer-use""#))
         XCTAssertTrue(response!.contains(#""tools":{"listChanged":false}"#))
@@ -334,7 +334,7 @@ final class OpenComputerUseKitTests: XCTestCase {
     func testInitializeResponseContainsComputerUseInstructions() throws {
         let server = StdioMCPServer(service: ComputerUseService())
         let response = try XCTUnwrap(
-            server.handle(line: #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"test","version":"0.1.30"},"capabilities":{}}}"#)
+            server.handle(line: #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"test","version":"0.1.32"},"capabilities":{}}}"#)
         )
         let data = try XCTUnwrap(response.data(using: .utf8))
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])

--- a/plugins/open-computer-use/.codex-plugin/plugin.json
+++ b/plugins/open-computer-use/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-computer-use",
-  "version": "0.1.30",
+  "version": "0.1.32",
   "description": "Open-source macOS Computer Use MCP server packaged as a Codex plugin.",
   "author": {
     "name": "Leo",

--- a/scripts/computer-use-cli/README.md
+++ b/scripts/computer-use-cli/README.md
@@ -131,7 +131,7 @@ Example working invocation against `open-computer-use`:
 ```bash
 go run . list-tools \
   --transport direct \
-  --server-bin ~/.codex/plugins/cache/open-computer-use-local/open-computer-use/0.1.30/scripts/launch-open-computer-use.sh
+  --server-bin ~/.codex/plugins/cache/open-computer-use-local/open-computer-use/0.1.32/scripts/launch-open-computer-use.sh
 ```
 
 Example working comparison flow against a local repo build:

--- a/scripts/computer-use-cli/main.go
+++ b/scripts/computer-use-cli/main.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	cliName                  = "computer-use-cli"
-	cliVersion               = "0.1.30"
+	cliVersion               = "0.1.32"
 	defaultTimeout           = 60 * time.Second
 	pluginRootEnvVar         = "COMPUTER_USE_PLUGIN_ROOT"
 	pluginVersionEnvVar      = "COMPUTER_USE_PLUGIN_VERSION"


### PR DESCRIPTION
## Summary
- bump the repo version sources from 0.1.30 to 0.1.32 across plugin, Swift, smoke, tests, and CLI helper docs
- backfill the missing 0.1.31 feature release note and add a 0.1.32 note for the version-line realignment
- add the matching history entry for this release-bump task

## Why
- origin already has tag and GitHub Release v0.1.31 on the current main commit, while the repo files still reported 0.1.30
- this PR moves the working tree back to a single release version source without rewriting the existing release

## Verification
- make check-docs
- swift test
- node ./scripts/npm/build-packages.mjs --out-dir dist/release/npm-staging-check
- ./scripts/build-cursor-motion-dmg.sh --configuration release --arch universal --version 0.1.32