### PR TITLE
Add Gemini/opencode MCP installers and bump to 0.1.33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .build/
 .swiftpm/
 dist/
+.gemini/
 artifacts/codex-dumps/
 research/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -44,8 +44,14 @@ Besides using the MCP JSON config above, you can also use the built-in subcomman
 ```bash
 # Install into Claude Code by writing to ~/.claude.json
 open-computer-use install-claude-mcp
+# Install into Gemini CLI for the current project by writing to ./.gemini/settings.json
+open-computer-use install-gemini-mcp
+# Install into Gemini CLI user config instead
+open-computer-use install-gemini-mcp --scope user
 # Install into Codex by writing to ~/.codex/config.toml
 open-computer-use install-codex-mcp
+# Install into opencode by writing to ~/.config/opencode/opencode.json (or the active config file)
+open-computer-use install-opencode-mcp
 # Install as a Codex plugin, mainly for Codex App usage; if you use this, you usually do not need install-codex-mcp as well
 open-computer-use install-codex-plugin
 # Start the MCP server directly

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,8 +45,17 @@ open-computer-use
 # 一键安装到 Claude Code，写到 ~/.claude.json 中
 open-computer-use install-claude-mcp
 
+# 一键安装到 Gemini CLI 当前项目，写到 ./.gemini/settings.json
+open-computer-use install-gemini-mcp
+
+# 一键安装到 Gemini CLI 用户级配置
+open-computer-use install-gemini-mcp --scope user
+
 # 一键安装到 Codex，写到 ~/.codex/config.toml 中
 open-computer-use install-codex-mcp
+
+# 一键安装到 opencode，写到 ~/.config/opencode/opencode.json（或当前生效的配置文件）
+open-computer-use install-opencode-mcp
 
 # 一键安装到 Codex 插件，主要方便在 Codex App 中使用
 open-computer-use install-codex-plugin

--- a/apps/OpenComputerUseSmokeSuite/Sources/OpenComputerUseSmokeSuite/main.swift
+++ b/apps/OpenComputerUseSmokeSuite/Sources/OpenComputerUseSmokeSuite/main.swift
@@ -35,7 +35,7 @@ final class MCPClient {
         _ = try request(method: "initialize", params: [
             "clientInfo": [
                 "name": "OpenComputerUseSmokeSuite",
-                "version": "0.1.32",
+                "version": "0.1.33",
             ],
             "capabilities": [:],
             "protocolVersion": "2025-03-26",

--- a/docs/histories/2026-04/20260422-1816-add-gemini-opencode-mcp-installers.md
+++ b/docs/histories/2026-04/20260422-1816-add-gemini-opencode-mcp-installers.md
@@ -1,0 +1,30 @@
+## [2026-04-22 18:16] | Task: 增加 Gemini 和 opencode 的 MCP 安装支持
+
+### 🤖 Execution Context
+* **Agent ID**: `Codex`
+* **Base Model**: `GPT-5 family (Codex)`
+* **Runtime**: `Codex CLI on macOS`
+
+### 📥 User Query
+> add quick support for gemini and opencode, you can test it by run gemini and opencode from command line
+
+### 🛠 Changes Overview
+**Scope:** 安装脚本、npm launcher、README 文档
+
+**Key Actions:**
+- **[Installer Support]**: 新增 `scripts/install-gemini-mcp.sh` 和 `scripts/install-opencode-mcp.sh`，分别对接 Gemini CLI 和 opencode 的 MCP 配置格式。
+- **[Shared Config Helper]**: 扩展 `scripts/install-config-helper.mjs`，支持 Gemini JSON 配置写入，以及 opencode `mcp.<name> = { type: "local", command: [...] }` 的幂等安装与旧别名清理。
+- **[Packaging and Docs]**: 更新 `README.md`、`README.zh-CN.md` 和 npm launcher/build 脚本，让 npm 安装后的 `open-computer-use` 也能直接转发 `install-gemini-mcp` / `install-opencode-mcp`。
+- **[Repo Hygiene]**: 将 `.gemini/` 加入 `.gitignore`，避免 Gemini 默认 project-scope 安装把本地配置噪音带进工作区。
+
+### 🧠 Design Intent (Why)
+这次改动延续仓库现有的“内置 install 子命令”模式，而不是要求用户手动查不同 host CLI 的配置格式。Gemini 默认是项目级 `.gemini/settings.json`，opencode 则会合并多个 JSON 配置文件，所以 helper 需要显式处理目标文件选择、幂等写入和旧别名清理，避免用户安装一次后留下重复配置或脏工作区。
+
+### 📁 Files Modified
+- `.gitignore`
+- `README.md`
+- `README.zh-CN.md`
+- `scripts/install-config-helper.mjs`
+- `scripts/install-gemini-mcp.sh`
+- `scripts/install-opencode-mcp.sh`
+- `scripts/npm/build-packages.mjs`

--- a/docs/histories/2026-04/20260422-1828-bump-open-computer-use-to-0.1.33.md
+++ b/docs/histories/2026-04/20260422-1828-bump-open-computer-use-to-0.1.33.md
@@ -1,0 +1,30 @@
+## [2026-04-22 18:28] | Task: 发布 0.1.33
+
+### Execution Context
+* **Agent ID**: `Codex`
+* **Base Model**: `GPT-5`
+* **Runtime**: `local macOS shell`
+
+### User Query
+> bump a version and submit a pr
+
+### Changes Overview
+**Scope:** release version sources, feature release notes, task history
+
+**Key Actions:**
+- **[Version Bump]**: 将 Open Computer Use 的主版本源和相关测试/文档示例统一从 `0.1.32` bump 到 `0.1.33`。
+- **[Release Notes]**: 在 `docs/releases/feature-release-notes.md` 记录本次 patch release 聚焦 Gemini CLI 和 opencode 的 MCP 安装支持。
+- **[PR Prep]**: 基于本地新增的 Gemini/opencode 安装器提交，收口新的 release 版本线，供后续分支推送和 PR 使用。
+
+### Design Intent
+这轮版本 bump 的目标不是发布一个抽象的“文档修正”，而是把刚加入的 Gemini / opencode host 集成正式纳入对外版本线。既然当前 `HEAD` 相比远端 `v0.1.32` 已经多了用户可感知的新安装命令，就应该顺延到 `0.1.33`，保持功能提交、版本源和用户可见 release notes 一致。
+
+### Files Modified
+- `plugins/open-computer-use/.codex-plugin/plugin.json`
+- `packages/OpenComputerUseKit/Sources/OpenComputerUseKit/OpenComputerUseVersion.swift`
+- `apps/OpenComputerUseSmokeSuite/Sources/OpenComputerUseSmokeSuite/main.swift`
+- `packages/OpenComputerUseKit/Tests/OpenComputerUseKitTests/OpenComputerUseKitTests.swift`
+- `scripts/computer-use-cli/main.go`
+- `scripts/computer-use-cli/README.md`
+- `docs/releases/feature-release-notes.md`
+- `docs/histories/2026-04/20260422-1828-bump-open-computer-use-to-0.1.33.md`

--- a/docs/releases/feature-release-notes.md
+++ b/docs/releases/feature-release-notes.md
@@ -4,6 +4,7 @@
 
 | 日期 | 功能域 | 用户价值 | 变更摘要 |
 | --- | --- | --- | --- |
+| 2026-04-22 | Gemini / opencode MCP 安装 | Gemini CLI 和 opencode 用户现在也能像 Claude Code / Codex 一样用仓库内置命令完成 `open-computer-use` 的 MCP 接入，不需要再手动查各自配置格式。 | 发布 `0.1.33`，新增 `install-gemini-mcp` 和 `install-opencode-mcp`，将 npm launcher、README 与共享配置 helper 一并补齐，并让 Gemini 默认 project-scope 配置不会污染仓库 git 状态。 |
 | 2026-04-22 | 发布版本重新对齐 | GitHub Release tag、插件 manifest 和仓库内版本常量重新回到同一个版本线；后续本地安装、staging 和诊断不会再出现 “release 已是新版本，但产物仍显示旧值” 的混乱状态。 | 发布 `0.1.32`，在远端 `v0.1.31` 已存在的前提下，将 `plugin.json`、Swift 版本常量、smoke/test 初始化请求和 CLI helper 文档统一 bump 到 `0.1.32`，为下一次 release 保持单一版本源。 |
 | 2026-04-22 | 视觉光标落点与空闲态收口 | Retina 窗口里的坐标点击更准确，visual cursor 在等待下一次动作时也更稳定、更接近官方观感。 | 发布 `0.1.31`，修复 screenshot pixel 到 window point 的映射，避免 `click({x,y})` 在高分屏上点偏；同时把 idle cursor 收敛为 30 秒停驻、保持压在目标窗口之上，并将等待态改成 anchored tip + tiny rotate wobble。 |
 | 2026-04-22 | Windows runtime 预览与发版说明 | Windows 用户和后续开发者现在有了实验性 Computer Use runtime 起点；每次 GitHub Release 也会保留面向用户的变更摘要，不再只留下 changelog 链接。 | 发布 `0.1.30`，新增实验性 Go/PowerShell Windows runtime、构建脚本和文档；同时明确 release agent 在 bump 版本后必须检查 GitHub 自动 release notes，必要时手动补 `What's Changed`。 |

--- a/packages/OpenComputerUseKit/Sources/OpenComputerUseKit/OpenComputerUseVersion.swift
+++ b/packages/OpenComputerUseKit/Sources/OpenComputerUseKit/OpenComputerUseVersion.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public let openComputerUseVersion = "0.1.32"
+public let openComputerUseVersion = "0.1.33"
 
 public func resolvedOpenComputerUseVersion(bundle: Bundle = .main) -> String {
     if let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,

--- a/packages/OpenComputerUseKit/Tests/OpenComputerUseKitTests/OpenComputerUseKitTests.swift
+++ b/packages/OpenComputerUseKit/Tests/OpenComputerUseKitTests/OpenComputerUseKitTests.swift
@@ -325,7 +325,7 @@ final class OpenComputerUseKitTests: XCTestCase {
 
     func testInitializeResponseContainsToolsCapability() throws {
         let server = StdioMCPServer(service: ComputerUseService())
-        let response = server.handle(line: #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"test","version":"0.1.32"},"capabilities":{}}}"#)
+        let response = server.handle(line: #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"test","version":"0.1.33"},"capabilities":{}}}"#)
         XCTAssertNotNil(response)
         XCTAssertTrue(response!.contains(#""name":"open-computer-use""#))
         XCTAssertTrue(response!.contains(#""tools":{"listChanged":false}"#))
@@ -334,7 +334,7 @@ final class OpenComputerUseKitTests: XCTestCase {
     func testInitializeResponseContainsComputerUseInstructions() throws {
         let server = StdioMCPServer(service: ComputerUseService())
         let response = try XCTUnwrap(
-            server.handle(line: #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"test","version":"0.1.32"},"capabilities":{}}}"#)
+            server.handle(line: #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"test","version":"0.1.33"},"capabilities":{}}}"#)
         )
         let data = try XCTUnwrap(response.data(using: .utf8))
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])

--- a/plugins/open-computer-use/.codex-plugin/plugin.json
+++ b/plugins/open-computer-use/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-computer-use",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Open-source macOS Computer Use MCP server packaged as a Codex plugin.",
   "author": {
     "name": "Leo",

--- a/scripts/computer-use-cli/README.md
+++ b/scripts/computer-use-cli/README.md
@@ -131,7 +131,7 @@ Example working invocation against `open-computer-use`:
 ```bash
 go run . list-tools \
   --transport direct \
-  --server-bin ~/.codex/plugins/cache/open-computer-use-local/open-computer-use/0.1.32/scripts/launch-open-computer-use.sh
+  --server-bin ~/.codex/plugins/cache/open-computer-use-local/open-computer-use/0.1.33/scripts/launch-open-computer-use.sh
 ```
 
 Example working comparison flow against a local repo build:

--- a/scripts/computer-use-cli/main.go
+++ b/scripts/computer-use-cli/main.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	cliName                  = "computer-use-cli"
-	cliVersion               = "0.1.32"
+	cliVersion               = "0.1.33"
 	defaultTimeout           = 60 * time.Second
 	pluginRootEnvVar         = "COMPUTER_USE_PLUGIN_ROOT"
 	pluginVersionEnvVar      = "COMPUTER_USE_PLUGIN_VERSION"

--- a/scripts/install-config-helper.mjs
+++ b/scripts/install-config-helper.mjs
@@ -12,6 +12,8 @@ function usage() {
   process.stdout.write(`Usage:
   node ./scripts/install-config-helper.mjs claude-mcp <config-path> <project-root> <server-name> <command-name>
   node ./scripts/install-config-helper.mjs codex-mcp <config-path> <server-name> <command-name>
+  node ./scripts/install-config-helper.mjs gemini-mcp <config-path> <server-name> <command-name>
+  node ./scripts/install-config-helper.mjs opencode-mcp <primary-config-path> <secondary-config-path> <server-name> <command-name>
   node ./scripts/install-config-helper.mjs codex-plugin-version <plugin-manifest-path>
   node ./scripts/install-config-helper.mjs codex-plugin-config <config-path> <repo-root> <marketplace-name> <plugin-name>
   node ./scripts/install-config-helper.mjs copy-into-dir <target-dir> <source-path> [<source-path> ...]
@@ -27,6 +29,53 @@ function readTextIfExists(filePath) {
 
 function ensureParentDir(filePath) {
   mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function readJSONObjectConfig(configPath, label) {
+  const raw = readTextIfExists(configPath);
+  if (raw.trim().length === 0) {
+    return {};
+  }
+
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (error) {
+    fail(`Existing ${label} is not valid JSON: ${error.message}`);
+  }
+
+  if (data === null || Array.isArray(data) || typeof data !== "object") {
+    fail(`Existing ${label} root is not a JSON object; refusing to modify it.`);
+  }
+
+  return data;
+}
+
+function ensureObjectField(parent, key, label) {
+  const value = parent[key] ?? {};
+  if (value === null || Array.isArray(value) || typeof value !== "object") {
+    fail(label);
+  }
+  parent[key] = value;
+  return value;
+}
+
+function getOptionalObjectField(parent, key, label) {
+  if (!(key in parent) || parent[key] === undefined) {
+    return undefined;
+  }
+
+  const value = parent[key];
+  if (value === null || Array.isArray(value) || typeof value !== "object") {
+    fail(label);
+  }
+
+  return value;
+}
+
+function writeJSONConfig(configPath, data) {
+  ensureParentDir(configPath);
+  writeFileSync(configPath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
 }
 
 function normalizeNewlines(text) {
@@ -168,41 +217,18 @@ function installClaudeMcp(configPath, projectRoot, serverName, commandName) {
     args: ["mcp"],
   };
   const legacyServerName = "open-codex-computer-use";
-
-  const raw = readTextIfExists(configPath);
-  let data;
-
-  if (raw.trim().length === 0) {
-    data = {};
-  } else {
-    try {
-      data = JSON.parse(raw);
-    } catch (error) {
-      fail(`Existing Claude config is not valid JSON: ${error.message}`);
-    }
-  }
-
-  if (data === null || Array.isArray(data) || typeof data !== "object") {
-    fail("Existing Claude config root is not a JSON object; refusing to modify it.");
-  }
-
-  const projects = data.projects ?? {};
-  if (projects === null || Array.isArray(projects) || typeof projects !== "object") {
-    fail('Existing Claude config has non-object "projects"; refusing to modify it.');
-  }
-  data.projects = projects;
-
-  const projectEntry = projects[projectRoot] ?? {};
-  if (projectEntry === null || Array.isArray(projectEntry) || typeof projectEntry !== "object") {
-    fail(`Existing Claude project entry for ${projectRoot} is not an object; refusing to modify it.`);
-  }
-  projects[projectRoot] = projectEntry;
-
-  const mcpServers = projectEntry.mcpServers ?? {};
-  if (mcpServers === null || Array.isArray(mcpServers) || typeof mcpServers !== "object") {
-    fail(`Existing Claude project MCP config for ${projectRoot} is not an object; refusing to modify it.`);
-  }
-  projectEntry.mcpServers = mcpServers;
+  const data = readJSONObjectConfig(configPath, `Claude config ${configPath}`);
+  const projects = ensureObjectField(data, "projects", 'Existing Claude config has non-object "projects"; refusing to modify it.');
+  const projectEntry = ensureObjectField(
+    projects,
+    projectRoot,
+    `Existing Claude project entry for ${projectRoot} is not an object; refusing to modify it.`,
+  );
+  const mcpServers = ensureObjectField(
+    projectEntry,
+    "mcpServers",
+    `Existing Claude project MCP config for ${projectRoot} is not an object; refusing to modify it.`,
+  );
 
   const target = mcpServers[serverName];
   const legacy = mcpServers[legacyServerName];
@@ -219,14 +245,133 @@ function installClaudeMcp(configPath, projectRoot, serverName, commandName) {
     delete mcpServers[legacyServerName];
   }
 
-  ensureParentDir(configPath);
-  writeFileSync(configPath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  writeJSONConfig(configPath, data);
 
   if (targetMatches && legacyMatches) {
     process.stdout.write(`Claude MCP server "${serverName}" was already installed for ${projectRoot}; removed legacy alias "${legacyServerName}" from ${configPath}.\n`);
   } else {
     process.stdout.write(`Installed Claude MCP server "${serverName}" for ${projectRoot} into ${configPath}.\n`);
   }
+}
+
+function installGeminiMcp(configPath, serverName, commandName) {
+  const desiredEntry = {
+    command: commandName,
+    args: ["mcp"],
+  };
+  const legacyServerName = "open-codex-computer-use";
+  const data = readJSONObjectConfig(configPath, `Gemini config ${configPath}`);
+  const mcpServers = ensureObjectField(
+    data,
+    "mcpServers",
+    `Existing Gemini config has non-object "mcpServers"; refusing to modify it.`,
+  );
+
+  const target = mcpServers[serverName];
+  const legacy = mcpServers[legacyServerName];
+  const targetMatches = JSON.stringify(target) === JSON.stringify(desiredEntry);
+  const legacyMatches = JSON.stringify(legacy) === JSON.stringify(desiredEntry);
+
+  if (targetMatches && !legacyMatches) {
+    process.stdout.write(`Gemini MCP server "${serverName}" is already installed in ${configPath}.\n`);
+    return;
+  }
+
+  mcpServers[serverName] = desiredEntry;
+  if (legacyMatches) {
+    delete mcpServers[legacyServerName];
+  }
+
+  writeJSONConfig(configPath, data);
+
+  if (targetMatches && legacyMatches) {
+    process.stdout.write(`Gemini MCP server "${serverName}" was already installed; removed legacy alias "${legacyServerName}" from ${configPath}.\n`);
+  } else {
+    process.stdout.write(`Installed Gemini MCP server "${serverName}" into ${configPath}.\n`);
+  }
+}
+
+function installOpencodeMcp(primaryConfigPath, secondaryConfigPath, serverName, commandName) {
+  const desiredEntry = {
+    type: "local",
+    command: [commandName, "mcp"],
+  };
+  const legacyServerName = "open-codex-computer-use";
+  const configEntries = [{ path: primaryConfigPath, role: "primary" }];
+  if (secondaryConfigPath && secondaryConfigPath !== primaryConfigPath) {
+    configEntries.push({ path: secondaryConfigPath, role: "secondary" });
+  }
+
+  const records = configEntries.map((entry) => ({
+    ...entry,
+    data: readJSONObjectConfig(entry.path, `opencode config ${entry.path}`),
+    dirty: false,
+  }));
+
+  const targetMatches = [];
+  const extraAliases = [];
+  for (const record of records) {
+    const mcp = getOptionalObjectField(
+      record.data,
+      "mcp",
+      `Existing opencode config has non-object "mcp" in ${record.path}; refusing to modify it.`,
+    );
+    if (!mcp) {
+      continue;
+    }
+
+    if (JSON.stringify(mcp[serverName]) === JSON.stringify(desiredEntry)) {
+      targetMatches.push(record.path);
+    }
+    if (serverName in mcp || legacyServerName in mcp) {
+      extraAliases.push(record.path);
+    }
+  }
+
+  if (targetMatches.length === 1 && extraAliases.length === 1 && targetMatches[0] === extraAliases[0]) {
+    process.stdout.write(`opencode MCP server "${serverName}" is already installed in ${targetMatches[0]}.\n`);
+    return;
+  }
+
+  for (const record of records) {
+    const mcp = ensureObjectField(
+      record.data,
+      "mcp",
+      `Existing opencode config has non-object "mcp" in ${record.path}; refusing to modify it.`,
+    );
+
+    if (record.role === "primary") {
+      if (JSON.stringify(mcp[serverName]) !== JSON.stringify(desiredEntry)) {
+        mcp[serverName] = desiredEntry;
+        record.dirty = true;
+      }
+      if (legacyServerName in mcp) {
+        delete mcp[legacyServerName];
+        record.dirty = true;
+      }
+      continue;
+    }
+
+    if (serverName in mcp) {
+      delete mcp[serverName];
+      record.dirty = true;
+    }
+    if (legacyServerName in mcp) {
+      delete mcp[legacyServerName];
+      record.dirty = true;
+    }
+    if (Object.keys(mcp).length === 0) {
+      delete record.data.mcp;
+    }
+  }
+
+  for (const record of records) {
+    if (record.dirty) {
+      writeJSONConfig(record.path, record.data);
+    }
+  }
+
+  process.stdout.write(`Installed opencode MCP server "${serverName}" into ${primaryConfigPath}.\n`);
 }
 
 function installCodexMcp(configPath, serverName, commandName) {
@@ -346,6 +491,20 @@ function main(argv) {
         process.exit(1);
       }
       installCodexMcp(...args);
+      return;
+    case "gemini-mcp":
+      if (args.length !== 3) {
+        usage();
+        process.exit(1);
+      }
+      installGeminiMcp(...args);
+      return;
+    case "opencode-mcp":
+      if (args.length !== 4) {
+        usage();
+        process.exit(1);
+      }
+      installOpencodeMcp(...args);
       return;
     case "codex-plugin-version":
       if (args.length !== 1) {

--- a/scripts/install-gemini-mcp.sh
+++ b/scripts/install-gemini-mcp.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+config_helper="${script_dir}/install-config-helper.mjs"
+server_name="open-computer-use"
+command_name="open-computer-use"
+scope="project"
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/install-gemini-mcp.sh [--scope project|user]
+
+Install the open-computer-use stdio MCP entry into Gemini CLI config.
+Defaults to project scope, which writes ./.gemini/settings.json for the current project.
+Set GEMINI_CONFIG_PATH to override the target file directly.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --scope)
+      if [[ $# -lt 2 ]]; then
+        echo "--scope requires a value" >&2
+        usage >&2
+        exit 1
+      fi
+      scope="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "${scope}" in
+  project)
+    default_config_path="$(pwd -P)/.gemini/settings.json"
+    ;;
+  user)
+    default_config_path="${HOME}/.gemini/settings.json"
+    ;;
+  *)
+    echo "Unsupported Gemini scope: ${scope}" >&2
+    usage >&2
+    exit 1
+    ;;
+esac
+
+config_path="${GEMINI_CONFIG_PATH:-${default_config_path}}"
+
+node "${config_helper}" gemini-mcp "${config_path}" "${server_name}" "${command_name}"

--- a/scripts/install-opencode-mcp.sh
+++ b/scripts/install-opencode-mcp.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+config_helper="${script_dir}/install-config-helper.mjs"
+server_name="open-computer-use"
+command_name="open-computer-use"
+opencode_config_dir="${XDG_CONFIG_HOME:-${HOME}/.config}/opencode"
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/install-opencode-mcp.sh
+
+Install the open-computer-use stdio MCP entry into opencode config.
+Set OPENCODE_CONFIG_PATH to override the primary config file directly.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "${OPENCODE_CONFIG_PATH:-}" ]]; then
+  primary_config_path="${OPENCODE_CONFIG_PATH}"
+  secondary_config_path=""
+elif [[ -f "${opencode_config_dir}/opencode.json" ]]; then
+  primary_config_path="${opencode_config_dir}/opencode.json"
+  secondary_config_path="${opencode_config_dir}/config.json"
+elif [[ -f "${opencode_config_dir}/config.json" ]]; then
+  primary_config_path="${opencode_config_dir}/config.json"
+  secondary_config_path="${opencode_config_dir}/opencode.json"
+else
+  primary_config_path="${opencode_config_dir}/opencode.json"
+  secondary_config_path="${opencode_config_dir}/config.json"
+fi
+
+node "${config_helper}" opencode-mcp "${primary_config_path}" "${secondary_config_path}" "${server_name}" "${command_name}"

--- a/scripts/npm/build-packages.mjs
+++ b/scripts/npm/build-packages.mjs
@@ -157,7 +157,9 @@ Commands:
   call <tool>           Call one tool, or run a JSON array of tool calls.
   turn-ended           Notify the running MCP process that the host turn ended.
   install-claude-mcp   Install the MCP server into ~/.claude.json for this project.
+  install-gemini-mcp   Install the MCP server into Gemini CLI config.
   install-codex-mcp    Install the MCP server into ~/.codex/config.toml.
+  install-opencode-mcp Install the MCP server into ~/.config/opencode.
   install-codex-plugin Install this npm package into the local Codex plugin cache.
   help [command]       Show general or command-specific help.
   version              Print the CLI version.
@@ -183,7 +185,9 @@ done
 package_root="$(cd "$(dirname "\${script_path}")/.." && pwd)"
 app_binary="\${package_root}/dist/${appBundleName}/Contents/MacOS/${appExecutableName}"
 install_claude_mcp_script="\${package_root}/scripts/install-claude-mcp.sh"
+install_gemini_mcp_script="\${package_root}/scripts/install-gemini-mcp.sh"
 install_mcp_script="\${package_root}/scripts/install-codex-mcp.sh"
+install_opencode_mcp_script="\${package_root}/scripts/install-opencode-mcp.sh"
 install_script="\${package_root}/scripts/install-codex-plugin.sh"
 
 if [[ "\${1:-}" == "install-claude-mcp" || "\${1:-}" == "install-clauce-mcp" ]]; then
@@ -191,9 +195,19 @@ if [[ "\${1:-}" == "install-claude-mcp" || "\${1:-}" == "install-clauce-mcp" ]];
   exec "\${install_claude_mcp_script}" "$@"
 fi
 
+if [[ "\${1:-}" == "install-gemini-mcp" ]]; then
+  shift
+  exec "\${install_gemini_mcp_script}" "$@"
+fi
+
 if [[ "\${1:-}" == "install-codex-mcp" ]]; then
   shift
   exec "\${install_mcp_script}" "$@"
+fi
+
+if [[ "\${1:-}" == "install-opencode-mcp" ]]; then
+  shift
+  exec "\${install_opencode_mcp_script}" "$@"
 fi
 
 if [[ "\${1:-}" == "install-codex-plugin" ]]; then
@@ -227,6 +241,26 @@ Usage:
   open-computer-use install-codex-mcp
 
 Install the open-computer-use MCP server into ~/.codex/config.toml.
+EOF
+  exit 0
+fi
+
+if [[ "\${1:-}" == "help" && "\${2:-}" == "install-gemini-mcp" ]]; then
+  cat <<'EOF'
+Usage:
+  open-computer-use install-gemini-mcp [--scope project|user]
+
+Install the open-computer-use MCP server into Gemini CLI config.
+EOF
+  exit 0
+fi
+
+if [[ "\${1:-}" == "help" && "\${2:-}" == "install-opencode-mcp" ]]; then
+  cat <<'EOF'
+Usage:
+  open-computer-use install-opencode-mcp
+
+Install the open-computer-use MCP server into ~/.config/opencode.
 EOF
   exit 0
 fi
@@ -270,7 +304,7 @@ const lines = [
   "Next:",
   "1. Run open-computer-use doctor",
   "2. In macOS System Settings, grant Accessibility and Screen Recording to your host terminal or MCP client",
-  "3. Run open-computer-use install-claude-mcp for Claude Code, open-computer-use install-codex-mcp for Codex, or open-computer-use install-codex-plugin for the local plugin cache",
+  "3. Run open-computer-use install-claude-mcp, install-gemini-mcp, install-codex-mcp, or install-opencode-mcp for your host CLI, or install-codex-plugin for the local Codex plugin cache",
   "",
   "You can add this to any MCP-capable client:",
   JSON.stringify(mcpConfig, null, 2),
@@ -331,8 +365,15 @@ open-computer-use --version
 # Install into Claude Code for the current project
 open-computer-use install-claude-mcp
 
+# Install into Gemini CLI for the current project or user config
+open-computer-use install-gemini-mcp
+open-computer-use install-gemini-mcp --scope user
+
 # Install into Codex as a plain MCP entry in ~/.codex/config.toml
 open-computer-use install-codex-mcp
+
+# Install into opencode in ~/.config/opencode
+open-computer-use install-opencode-mcp
 
 # Check permissions first; if Accessibility / Screen Recording is missing, open the permission onboarding window
 # If both are already granted, this just prints the status and exits
@@ -405,8 +446,10 @@ function renderPackageJson(packageName, version) {
       "plugins/open-computer-use/assets/",
       "plugins/open-computer-use/scripts/",
       "scripts/install-claude-mcp.sh",
+      "scripts/install-gemini-mcp.sh",
       "scripts/install-config-helper.mjs",
       "scripts/install-codex-mcp.sh",
+      "scripts/install-opencode-mcp.sh",
       "scripts/install-codex-plugin.sh",
       "scripts/postinstall.mjs",
       "README.md",
@@ -433,8 +476,10 @@ function stagePackage(packageName, version, outDir) {
     recursive: true,
   });
   cpSync(path.join(repoRoot, "scripts", "install-claude-mcp.sh"), path.join(packageRoot, "scripts", "install-claude-mcp.sh"));
+  cpSync(path.join(repoRoot, "scripts", "install-gemini-mcp.sh"), path.join(packageRoot, "scripts", "install-gemini-mcp.sh"));
   cpSync(path.join(repoRoot, "scripts", "install-config-helper.mjs"), path.join(packageRoot, "scripts", "install-config-helper.mjs"));
   cpSync(path.join(repoRoot, "scripts", "install-codex-mcp.sh"), path.join(packageRoot, "scripts", "install-codex-mcp.sh"));
+  cpSync(path.join(repoRoot, "scripts", "install-opencode-mcp.sh"), path.join(packageRoot, "scripts", "install-opencode-mcp.sh"));
   cpSync(path.join(repoRoot, "scripts", "install-codex-plugin.sh"), path.join(packageRoot, "scripts", "install-codex-plugin.sh"));
   cpSync(path.join(repoRoot, "LICENSE"), path.join(packageRoot, "LICENSE"));
 
@@ -446,7 +491,9 @@ function stagePackage(packageName, version, outDir) {
   writeFileSync(path.join(packageRoot, "package.json"), `${JSON.stringify(renderPackageJson(packageName, version), null, 2)}\n`, "utf-8");
 
   chmodSync(path.join(packageRoot, "scripts", "install-claude-mcp.sh"), 0o755);
+  chmodSync(path.join(packageRoot, "scripts", "install-gemini-mcp.sh"), 0o755);
   chmodSync(path.join(packageRoot, "scripts", "install-codex-mcp.sh"), 0o755);
+  chmodSync(path.join(packageRoot, "scripts", "install-opencode-mcp.sh"), 0o755);
   chmodSync(path.join(packageRoot, "scripts", "install-codex-plugin.sh"), 0o755);
   removeJunkFiles(packageRoot);
 }


### PR DESCRIPTION
## Summary
- add built-in `install-gemini-mcp` and `install-opencode-mcp` flows beside the existing Claude/Codex installers
- extend the shared install helper, npm launcher, docs, and gitignore for the new host integrations
- bump all release version anchors to `0.1.33` and record the release note/history entry

## Validation
- `swift test`
- `node ./scripts/npm/build-packages.mjs --skip-build --out-dir dist/release/npm-staging-check`
- `node -p "require('./dist/release/npm-staging-check/open-codex-computer-use-mcp/package.json').version"`
- `./scripts/build-cursor-motion-dmg.sh --configuration release --arch universal --version 0.1.33`
