### PR TITLE
docs: add Gemini demo attachment link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 [![Open Computer Use custom demo cover](./docs/generated/readme-assets/open-computer-use-demo-cover.png)](https://youtu.be/2s6aVpGiwaQ)
 
+https://github.com/user-attachments/assets/eacb3b15-f939-46c7-b3b3-6f876977a58d
+
+<sub><em>Gemini CLI connected to `open-computer-use` through MCP, driving real Computer Use actions end to end.</em></sub>
+
 `open-computer-use` is an open-source `Computer Use` service exposed over `MCP`, so any AI agent or MCP client can call it directly and use computer interaction capabilities on macOS. An experimental Windows runtime now lives in this repo too, with the same 9-tool surface implemented as a standalone Go-built `.exe`.
 
 This project was inspired by OpenAI's recently released [Codex Computer Use](https://openai.com/index/codex-for-almost-everything/). It showed that non-intrusive CUA can be built on top of macOS Accessibility, which is why I decided to build an open-source version.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,6 +4,10 @@
 
 [![open-computer-use 自定义演示封面](./docs/generated/readme-assets/open-computer-use-demo-cover.png)](https://youtu.be/2s6aVpGiwaQ)
 
+https://github.com/user-attachments/assets/eacb3b15-f939-46c7-b3b3-6f876977a58d
+
+<sub><em>Gemini CLI 作为 host 接入 `open-computer-use` MCP，并完整触发真实的 Computer Use 操作。</em></sub>
+
 `open-computer-use` 是一个开源的 `Computer Use` 服务，已经包装成 `MCP` 协议，支持所有的 AI Agent 或 MCP Client 快速调用，实现 macOS 上的 `Computer Use` 能力。仓库里也已经新增实验性的 Windows runtime，用 Go 生成独立 `.exe`，暴露同样的 9 个 tool。
 
 项目的背后是 OpenAI 刚发布的 [Codex Computer Use](https://openai.com/index/codex-for-almost-everything/)，让我看到了基于 Accessibility 可以实现非抢占式 CUA 能力，因此决定复刻一个开源版本

--- a/docs/histories/2026-04/20260422-1952-add-gemini-cli-demo-video.md
+++ b/docs/histories/2026-04/20260422-1952-add-gemini-cli-demo-video.md
@@ -1,0 +1,25 @@
+## [2026-04-22 19:52] | Task: 增加 Gemini CLI MCP demo 视频到 README
+
+### 🤖 Execution Context
+* **Agent ID**: `Codex`
+* **Base Model**: `GPT-5 family (Codex)`
+* **Runtime**: `Codex CLI on macOS`
+
+### 📥 User Query
+> Copy the provided `output.mp4` into the repo for demo use, rename it if needed, and add it to the README with a description showing Gemini CLI using our MCP.
+
+### 🛠 Changes Overview
+**Scope:** README 文档、history
+
+**Key Actions:**
+- **[Attachment Link]**: 更新 `README.md` 和 `README.zh-CN.md`，直接使用用户提供的 GitHub `user-attachments` 视频链接，让 README 引用外部托管的视频资源，而不是把视频文件收进仓库。
+- **[Storage Cleanup]**: 清理这次任务里引入的本地视频 / GIF 资源提交，避免把大体积二进制文件继续留在分支历史里占用仓库存储。
+- **[History]**: 继续维护同一份 history，把最终的 README 呈现方式和存储取舍记录清楚。
+
+### 🧠 Design Intent (Why)
+这次任务的重点是让 README 直接引用 GitHub 已托管的视频，同时不把 `.mp4` / GIF 二进制继续塞进仓库历史里。这样既保留了 README 顶部的演示入口，也避免为了展示视频而给仓库长期增加不必要的存储负担。
+
+### 📁 Files Modified
+- `README.md`
+- `README.zh-CN.md`
+- `docs/histories/2026-04/20260422-1952-add-gemini-cli-demo-video.md`


### PR DESCRIPTION
## Summary
- add the GitHub attachment video URL near the top of both README files
- keep the demo description as a short italic annotation under the video
- record the README/history update without storing video or GIF assets in the repo

## Validation
- `make check-docs`

## Notes
- this PR intentionally uses a GitHub `user-attachments` URL instead of committing media files to the repository, to avoid adding large binary assets to git history