### PR TITLE
docs: add LLMAPIS badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [中文说明](./README.zh-CN.md)
 
+<a href="https://llmapis.com?source=https%3A%2F%2Fgithub.com%2FiFurySt%2Fopen-codex-computer-use" target="_blank"><img src="https://llmapis.com/api/badge/iFurySt/open-codex-computer-use" alt="LLMAPIS" width="80" /></a>
+
+*Partnership with [https://llmapis.com](https://llmapis.com) - Discover more AI tools and resources*
+
 [![Open Computer Use custom demo cover](./docs/generated/readme-assets/open-computer-use-demo-cover.png)](https://youtu.be/2s6aVpGiwaQ)
 
 https://github.com/user-attachments/assets/eacb3b15-f939-46c7-b3b3-6f876977a58d


### PR DESCRIPTION
Hi! Really enjoyed this project — I think `open-codex-computer-use` is one of the more interesting open-source efforts pushing **Computer Use** into an open, MCP-native runtime capability.

This PR proposes adding a small **LLMAPIS badge** to the README.

### What is LLMAPIS / Badge Network?

LLMAPIS is an AI-native portal focused on discovering and interpreting emerging AI projects, tools, and infrastructure. Its badge network helps connect open-source AI repos into a broader discovery layer, making strong projects easier to surface, contextualize, and revisit.

### Why add it here?

`open-codex-computer-use` is a strong fit for that network because it sits at the intersection of:

- AI agents
- MCP tooling
- computer use
- open runtime infrastructure

### Why this version of the badge?

This PR uses a **small-width badge (80px)** so it stays lightweight and does not visually disrupt the README.

If you'd prefer different placement or wording, happy to adjust.

Thanks again for open-sourcing this project.
