### PR TITLE
[codex] fix permission onboarding stale panel

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,7 +42,7 @@
 - 当用户从终端执行 macOS 版 `open-computer-use mcp`、`doctor`、`call`、`snapshot` 或 `list-apps` 时，CLI 会先通过 LaunchServices 启动同一个 `.app` bundle 的隐藏 app agent，并通过用户临时目录下的 Unix domain socket 转发请求；真正调用 Accessibility、ScreenCaptureKit 和动作 tools 的进程始终是 `Open Computer Use.app`，不是 iTerm / Terminal / Node launcher。
 - 主窗口负责渲染 `Accessibility` / `Screen & System Audio Recording` 两类权限卡片、`Allow` / `Done` 状态和 relaunch 后的状态收敛；当两项权限都已完成时会自动关闭，不再要求用户手动退出。
 - 辅助 drag panel 会跳转到对应的 `System Settings` 页面；点击 `Allow` 后，panel 会从主窗口里的按钮位置做一段 spring + curved frame 的入场，再落到 `System Settings` 内容区下沿。panel 默认保持在窗口右侧内容区下方居中并固定贴近窗口底边，不再依赖实时扫描权限页内部 `+ / -` 控件行；窗口层级上会显式排在当前 `System Settings` 窗口之上，避免被权限列表内容盖住，同时尽量减少对系统设置自身滚动区域的干扰。panel 内也补了显式返回按钮，允许用户中断当前 guidance、回到 onboarding 主窗口重新选择权限步骤。
-- 权限状态优先基于 TCC 持久授权记录判断，避免 CLI 子进程与 GUI app 对授权状态看到不一致的结果；正式 release 仍以 CI 打出来的 `Open Computer Use.app` 为准，而本地 debug/dev 打包现在显式命名为 `Open Computer Use (Dev).app`，并在 dev bundle 运行时优先认当前 dev 副本，避免系统设置里出现两个完全同名的条目。
+- 权限状态会合并 TCC 持久授权记录与当前 app 进程的 runtime preflight：TCC 中任一匹配 client 已授权即可视为 granted，避免 CLI 子进程与 GUI app 对授权状态看到不一致的结果；如果当前 `.app` 进程已经通过 `AXIsProcessTrusted()` / `CGPreflightScreenCaptureAccess()`，也会立即视为 granted，避免 stale 或不匹配的 TCC path 记录让 onboarding 浮层继续停留。正式 release 仍以 CI 打出来的 `Open Computer Use.app` 为准，而本地 debug/dev 打包现在显式命名为 `Open Computer Use (Dev).app`，并在 dev bundle 运行时优先认当前 dev 副本，避免系统设置里出现两个完全同名的条目。
 
 ### 2. MCP 层
 
@@ -138,6 +138,7 @@
 - cursor lab 构建：`swift build --product CursorMotion`
 - 端到端 smoke：`./scripts/run-tool-smoke-tests.sh`（标准 9-tool smoke + visual cursor idle smoke；脚本默认以 headless 模式启动内部 fixture，避免在用户桌面弹出测试窗口）
 - app 打包：`./scripts/build-open-computer-use-app.sh debug`
+- 权限 onboarding 端到端回归：`./scripts/run-permission-onboarding-e2e.sh`（需要当前 macOS 对被测 `open-computer-use` 已授予 Accessibility 与 Screen Recording；默认禁用 app-agent proxy 来测试当前 CLI 运行态，可用 `OPEN_COMPUTER_USE_E2E_CLI=/path/to/open-computer-use` 指定被测 CLI，或用 `OPEN_COMPUTER_USE_E2E_DISABLE_APP_AGENT_PROXY=0` 显式覆盖默认代理行为）
 - npm staging：`node ./scripts/npm/build-packages.mjs`
 - release tgz：`./scripts/release-package.sh`
 - skill 打包：`npm run package:skill`

--- a/docs/histories/2026-05/20260520-1641-fix-permission-onboarding-stale-panel.md
+++ b/docs/histories/2026-05/20260520-1641-fix-permission-onboarding-stale-panel.md
@@ -1,0 +1,36 @@
+# 修复权限浮层完成后不消失
+
+## 用户诉求
+
+用户执行 `open-computer-use doctor` 已显示 `accessibility=granted, screenRecording=granted`，但 System Settings 上方的 `Drag Open Computer Use...` 授权辅助浮层仍然持续显示。
+
+## 主要改动
+
+- `PermissionDiagnostics.current()` 现在合并 TCC 持久授权记录与当前 app 进程的 runtime preflight 结果。
+- TCC 中任一匹配 client 已授权时仍视为 granted，保留 app-agent / CLI 之间的稳定判断。
+- 如果当前运行中的 `.app` 进程已经通过 `AXIsProcessTrusted()` 或 `CGPreflightScreenCaptureAccess()`，也立即视为 granted，避免 stale 或不匹配的 TCC path 查询结果覆盖真实运行态权限。
+- 增加单测覆盖 persisted/runtime 权限合并规则。
+- 新增 `scripts/run-permission-onboarding-e2e.sh`，在真实本机授权环境中先检查 `doctor` 已 granted，再断言无参数 onboarding 启动会快速退出，不会继续挂住浮层；脚本默认禁用 app-agent proxy，避免本地 ad-hoc `.app` 授权身份干扰当前 CLI 运行态回归。
+- 更新架构文档里的权限判断说明。
+
+## 设计动机
+
+onboarding 浮层是否消失取决于 `PermissionDiagnostics.current()` 的轮询结果。此前代码优先采用 TCC 数据库查询结果；当 TCC 查询因为 path/client 不匹配或 stale 记录返回 `false` 时，即使当前 app 进程实际已经拥有权限，也不会再 fallback 到 runtime preflight。这样就可能出现 CLI `doctor` 已经显示 granted，但旧的 onboarding UI 仍认为权限缺失并继续悬浮的状态。
+
+新的合并规则把 TCC grant 和当前进程 runtime grant 都当成可信正信号，避免授权完成后的 UI 卡住。
+
+## 受影响文件
+
+- `packages/OpenComputerUseKit/Sources/OpenComputerUseKit/Permissions.swift`
+- `packages/OpenComputerUseKit/Tests/OpenComputerUseKitTests/OpenComputerUseKitTests.swift`
+- `scripts/run-permission-onboarding-e2e.sh`
+- `docs/ARCHITECTURE.md`
+
+## 验证
+
+- `swift test --filter Permission`
+- `swift test`
+- `./scripts/check-docs.sh`
+- `git diff --check`
+- `.build/debug/OpenComputerUse doctor`
+- `./scripts/run-permission-onboarding-e2e.sh`

--- a/packages/OpenComputerUseKit/Sources/OpenComputerUseKit/Permissions.swift
+++ b/packages/OpenComputerUseKit/Sources/OpenComputerUseKit/Permissions.swift
@@ -70,10 +70,18 @@ public struct PermissionDiagnostics: Sendable {
 
     public static func current() -> PermissionDiagnostics {
         let persisted = TCCAuthorizationStore.current
+        let runtimeAccessibilityTrusted = AXIsProcessTrusted()
+        let runtimeScreenCaptureGranted = CGPreflightScreenCaptureAccess()
 
         return PermissionDiagnostics(
-            accessibilityTrusted: persisted.accessibility ?? AXIsProcessTrusted(),
-            screenCaptureGranted: persisted.screenRecording ?? CGPreflightScreenCaptureAccess()
+            accessibilityTrusted: permissionGranted(
+                persisted: persisted.accessibility,
+                runtime: runtimeAccessibilityTrusted
+            ),
+            screenCaptureGranted: permissionGranted(
+                persisted: persisted.screenRecording,
+                runtime: runtimeScreenCaptureGranted
+            )
         )
     }
 
@@ -455,6 +463,10 @@ public struct PermissionClientRecord: Sendable, Equatable, Hashable {
 
 func tccAuthorizationGranted(authValues: [Int32?]) -> Bool {
     authValues.contains(2)
+}
+
+func permissionGranted(persisted: Bool?, runtime: Bool) -> Bool {
+    (persisted == true) || runtime
 }
 
 private struct TCCAuthorizationStore {

--- a/packages/OpenComputerUseKit/Tests/OpenComputerUseKitTests/OpenComputerUseKitTests.swift
+++ b/packages/OpenComputerUseKit/Tests/OpenComputerUseKitTests/OpenComputerUseKitTests.swift
@@ -443,6 +443,14 @@ final class OpenComputerUseKitTests: XCTestCase {
         XCTAssertFalse(tccAuthorizationGranted(authValues: []))
     }
 
+    func testPermissionGrantedKeepsRuntimePreflightAuthoritativeForCurrentProcess() {
+        XCTAssertTrue(permissionGranted(persisted: false, runtime: true))
+        XCTAssertTrue(permissionGranted(persisted: nil, runtime: true))
+        XCTAssertTrue(permissionGranted(persisted: true, runtime: false))
+        XCTAssertFalse(permissionGranted(persisted: false, runtime: false))
+        XCTAssertFalse(permissionGranted(persisted: nil, runtime: false))
+    }
+
     func testKeyPressParserSupportsCommandStyleChord() throws {
         let parsed = try KeyPressParser.parse("super+c")
         XCTAssertEqual(parsed.displayValue, "c")

--- a/scripts/run-permission-onboarding-e2e.sh
+++ b/scripts/run-permission-onboarding-e2e.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cli="${OPEN_COMPUTER_USE_E2E_CLI:-${repo_root}/.build/debug/OpenComputerUse}"
+timeout_seconds="${OPEN_COMPUTER_USE_E2E_TIMEOUT_SECONDS:-3}"
+disable_app_agent_proxy="${OPEN_COMPUTER_USE_E2E_DISABLE_APP_AGENT_PROXY:-1}"
+
+cd "${repo_root}"
+
+if [[ -z "${OPEN_COMPUTER_USE_E2E_CLI:-}" ]]; then
+  swift build --product OpenComputerUse
+fi
+
+if [[ ! -x "${cli}" ]]; then
+  if command -v open-computer-use >/dev/null 2>&1; then
+    cli="$(command -v open-computer-use)"
+  else
+    echo "Missing executable: ${cli}" >&2
+    echo "Run swift build first, or set OPEN_COMPUTER_USE_E2E_CLI=/path/to/open-computer-use." >&2
+    exit 1
+  fi
+fi
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/open-computer-use-permission-e2e.XXXXXX")"
+cleanup() {
+  rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
+echo "Using CLI: ${cli}"
+if [[ "${disable_app_agent_proxy}" == "1" || "${disable_app_agent_proxy}" == "true" || "${disable_app_agent_proxy}" == "yes" ]]; then
+  echo "Using direct CLI permission checks (app-agent proxy disabled for this E2E)."
+  run_cli() {
+    OPEN_COMPUTER_USE_DISABLE_APP_AGENT_PROXY=1 "${cli}" "$@"
+  }
+else
+  echo "Using default CLI app-agent proxy behavior."
+  run_cli() {
+    "${cli}" "$@"
+  }
+fi
+
+doctor_output="$(run_cli doctor)"
+echo "${doctor_output}"
+
+if [[ "${doctor_output}" != *"accessibility=granted"* ]] || [[ "${doctor_output}" != *"screenRecording=granted"* ]]; then
+  echo "Expected doctor to report both permissions granted before running onboarding E2E." >&2
+  exit 1
+fi
+
+stdout_file="${tmpdir}/onboarding.stdout"
+stderr_file="${tmpdir}/onboarding.stderr"
+
+run_cli >"${stdout_file}" 2>"${stderr_file}" &
+pid="$!"
+
+deadline=$((SECONDS + timeout_seconds))
+exit_code=""
+while (( SECONDS < deadline )); do
+  if ! kill -0 "${pid}" 2>/dev/null; then
+    if wait "${pid}"; then
+      exit_code=0
+    else
+      exit_code="$?"
+    fi
+    break
+  fi
+  sleep 0.05
+done
+
+if [[ -z "${exit_code}" ]]; then
+  kill "${pid}" 2>/dev/null || true
+  wait "${pid}" 2>/dev/null || true
+  echo "Permission onboarding did not exit within ${timeout_seconds}s even though doctor reported granted." >&2
+  echo "--- stdout ---" >&2
+  cat "${stdout_file}" >&2
+  echo "--- stderr ---" >&2
+  cat "${stderr_file}" >&2
+  exit 1
+fi
+
+if [[ "${exit_code}" != "0" ]]; then
+  echo "Permission onboarding command exited with ${exit_code}." >&2
+  echo "--- stdout ---" >&2
+  cat "${stdout_file}" >&2
+  echo "--- stderr ---" >&2
+  cat "${stderr_file}" >&2
+  exit "${exit_code}"
+fi
+
+echo "Permission onboarding E2E passed: granted permissions do not leave onboarding running."


### PR DESCRIPTION
## Summary

Fix permission onboarding getting stuck after macOS permissions are already granted.

`PermissionDiagnostics.current()` now treats both persisted TCC grants and the current app process runtime preflight as positive permission signals. This keeps the onboarding UI aligned with `open-computer-use doctor` when TCC path/client records are stale or do not match the currently running process.

## Root Cause

The onboarding window polls `PermissionDiagnostics.current()` to decide whether to hide the System Settings accessory panel. That diagnostic previously preferred the persisted TCC database result whenever a record existed. If that query returned `false` for a stale or mismatched path/client, the code never fell back to `AXIsProcessTrusted()` / `CGPreflightScreenCaptureAccess()`, so a process that actually had permission could still keep showing the onboarding panel.

## Changes

- Merge persisted TCC authorization with runtime permission preflight.
- Add a unit test for the persisted/runtime permission merge rule.
- Add a macOS permission onboarding E2E script that verifies granted permissions do not leave onboarding running.
- Document the updated permission model and record the history note.

## Validation

- `swift test --filter Permission`
- `swift test`
- `./scripts/check-docs.sh`
- `git diff --check`
- `./scripts/run-permission-onboarding-e2e.sh`
- `OPEN_COMPUTER_USE_E2E_CLI="$(command -v open-computer-use)" ./scripts/run-permission-onboarding-e2e.sh`
