### PR TITLE
Fix UTF-8 parsing for Windows operation JSON params

### DIFF
--- a/apps/OpenComputerUseWindows/runtime.ps1
+++ b/apps/OpenComputerUseWindows/runtime.ps1
@@ -852,7 +852,12 @@ function Invoke-TypeText($process, [string]$text) {
     return $false
 }
 
-$operation = Get-Content -Raw -Path $OperationPath | ConvertFrom-Json
+# Read the operation file as UTF-8 explicitly. Windows PowerShell 5.1's
+# Get-Content defaults to the system ANSI code page (e.g. GBK on Chinese
+# systems) for files without a BOM, which corrupts non-ASCII input such as
+# Chinese text passed to set_value/type_text.
+$operationJson = [System.IO.File]::ReadAllText($OperationPath, [System.Text.Encoding]::UTF8)
+$operation = $operationJson | ConvertFrom-Json
 
 try {
     if ($operation.tool -eq "list_apps") {

--- a/docs/histories/2026-06/20260607-2320-windows-runtime-json-utf8-params.md
+++ b/docs/histories/2026-06/20260607-2320-windows-runtime-json-utf8-params.md
@@ -1,0 +1,23 @@
+## [2026-06-07 23:20] | Task: 修复 Windows runtime JSON 入参 UTF-8 解码
+
+### 🤖 Execution Context
+* **Agent ID**: `claude-opus-session`
+* **Base Model**: `gpt-5.3-codex-spark`
+* **Runtime**: `Windows PowerShell + Go`
+
+### 📥 User Query
+> 同步并发起 PR，修复 Windows runtime 中 `type_text` 与 `set_value` 的入参中文/非 ASCII 乱码问题。
+
+### 🛠 Changes Overview
+**Scope:** `apps/OpenComputerUseWindows/runtime.ps1`
+
+**Key Actions:**
+- **[Action 1]**: 将 MCP operation JSON 的读取从 `Get-Content -Raw` 改为 `[System.IO.File]::ReadAllText(..., [System.Text.Encoding]::UTF8)`。
+- **[Action 2]**: 保持 `type_text` 与 `set_value` 使用同一个 `$operation` 对象（`$operation.text`, `$operation.value`）读取路径，覆盖非 ASCII 入参场景。
+- **[Action 3]**: 在 `main` 同步到 `upstream/main` 后提交该补丁，确保 PR 只包含新增覆盖。
+
+### 🧠 Design Intent (Why)
+Windows PowerShell 5.1 在无 BOM 文件上可能使用系统 ANSI 编码（如中文环境下的 GBK），导致 JSON 中的非 ASCII 文本在 `Get-Content -Raw` 解析前被破坏。显式以 UTF-8 读取 operation 文件可避免该问题，确保 `type_text` 与 `set_value` 接收的入参保持原始内容。
+
+### 📁 Files Modified
+- `apps/OpenComputerUseWindows/runtime.ps1`


### PR DESCRIPTION
## Description

Follow-up to #24.

This PR addresses the remaining Windows UTF-8 path where non-ASCII operation parameters can be corrupted before dispatch. It specifically covers text passed through `type_text` (`$operation.text`) and `set_value` (`$operation.value`).

## Root Cause

#24 configured PowerShell output encoding, but the runtime still read the temporary operation JSON with `Get-Content -Raw`. On Windows PowerShell 5.1, files without a BOM can be decoded using the system ANSI code page (e.g. GBK/GB2312 for Chinese systems, CP936 for other locales) rather than UTF-8. That can corrupt non-ASCII JSON values before `ConvertFrom-Json` parses them.

## Changes

### 1. PowerShell Script (`runtime.ps1`)
- Replaced operation JSON loading with an explicit UTF-8 read:
  ```powershell
  $operationJson = [System.IO.File]::ReadAllText($OperationPath, [System.Text.Encoding]::UTF8)
  $operation = $operationJson | ConvertFrom-Json
  ```
- This preserves non-ASCII values used by `type_text` and `set_value`.

## Testing

All existing Windows runtime tests pass:

```bash
go test -v
# All 8 tests PASS
```

## Impact

This fix ensures non-ASCII text passed as Windows tool input parameters is decoded correctly before dispatch, including Chinese/Japanese/Korean/emoji text for `type_text` and `set_value`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>