### PR TITLE
Fix UTF-8 parsing for Windows operation JSON params

### DIFF
--- a/apps/OpenComputerUseWindows/runtime.ps1
+++ b/apps/OpenComputerUseWindows/runtime.ps1
@@ -852,7 +852,12 @@ function Invoke-TypeText($process, [string]$text) {
     return $false
 }
 
-$operation = Get-Content -Raw -Path $OperationPath | ConvertFrom-Json
+# Read the operation file as UTF-8 explicitly. Windows PowerShell 5.1's
+# Get-Content defaults to the system ANSI code page (e.g. GBK on Chinese
+# systems) for files without a BOM, which corrupts non-ASCII input such as
+# Chinese text passed to set_value/type_text.
+$operationJson = [System.IO.File]::ReadAllText($OperationPath, [System.Text.Encoding]::UTF8)
+$operation = $operationJson | ConvertFrom-Json
 
 try {
     if ($operation.tool -eq "list_apps") {


### PR DESCRIPTION
## Description

Follow-up to #24.

This PR addresses the remaining Windows UTF-8 path where non-ASCII operation parameters can be corrupted before dispatch. It specifically covers text passed through `type_text` (`$operation.text`) and `set_value` (`$operation.value`).

## Root Cause

#24 configured PowerShell output encoding, but the runtime still read the temporary operation JSON with `Get-Content -Raw`. On Windows PowerShell 5.1, files without a BOM can be decoded using the system ANSI code page (e.g. GBK/GB2312 for Chinese systems, CP936 for other locales) rather than UTF-8. That can corrupt non-ASCII JSON values before `ConvertFrom-Json` parses them.

## Changes

### 1. PowerShell Script (`runtime.ps1`)
- Replaced operation JSON loading with an explicit UTF-8 read:
  ```powershell
  $operationJson = [System.IO.File]::ReadAllText($OperationPath, [System.Text.Encoding]::UTF8)
  $operation = $operationJson | ConvertFrom-Json
  ```
- This preserves non-ASCII values used by `type_text` and `set_value`.

## Testing

All existing Windows runtime tests pass:

```bash
go test -v
# All 8 tests PASS
```

## Impact

This fix ensures non-ASCII text passed as Windows tool input parameters is decoded correctly before dispatch, including Chinese/Japanese/Korean/emoji text for `type_text` and `set_value`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>