### PR TITLE
docs(macos): 明确 macOS 14.0 最低系统要求

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ npm i -g open-computer-use
 
 The npm package also exposes `ocu` as the short CLI alias.
 
+> [!IMPORTANT]
+> The macOS runtime requires macOS 14.0 or later.
+
 **On macOS, run it once and grant `Accessibility` and `Screen Recording`. Windows and Linux do not need this step.**
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,7 +45,11 @@ npm i -g open-computer-use
 
 通过 npm 安装后也会同时提供短命令 `ocu`。
 
+> [!IMPORTANT]
+> macOS 运行环境要求 macOS 14.0 或更高版本。
+
 **macOS 第一次使用前，需要授权 `Accessibility` 和 `Screen Recording` 的权限，windows和linux无需执行**
+
 ```bash
 open-computer-use
 # 或

--- a/docs/histories/2026-07/20260710-1659-document-macos-14-requirement.md
+++ b/docs/histories/2026-07/20260710-1659-document-macos-14-requirement.md
@@ -1,0 +1,27 @@
+## [2026-07-10 16:59] | Task: 补充 macOS 14.0+ 系统要求
+
+### 🤖 Execution Context
+* **Agent ID**: `Codex`
+* **Base Model**: `GPT-5`
+* **Runtime**: `Codex Desktop`
+
+### 📥 User Query
+> 在 README 和 skill 文档中明确 macOS 运行环境要求 macOS 14.0 或更高版本，并说明低版本无法通过权限授权修复。
+
+### 🛠 Changes Overview
+**Scope:** `README.md`、`README.zh-CN.md`、`skills/open-computer-use`
+
+**Key Actions:**
+- **[双语 README]**: 在 Quick Start 中增加独立且醒目的 macOS 14.0+ 系统要求，和权限说明分开展示。
+- **[Skill 工作流]**: 要求 Agent 在调用 CLI 或 `doctor` 前先检查 macOS 版本，避免把二进制不兼容误判为权限问题。
+- **[安装与排障]**: 说明低于 macOS 14.0 时二进制无法启动，权限授权或 `doctor` 无法修复该兼容性错误。
+
+### 🧠 Design Intent (Why)
+让用户和 Agent 在安装及排障入口就能看到真实的最低系统要求，减少低版本 macOS 用户被错误引导到权限授权流程的情况。
+
+### 📁 Files Modified
+- `README.md`
+- `README.zh-CN.md`
+- `skills/open-computer-use/SKILL.md`
+- `skills/open-computer-use/references/installation.md`
+- `skills/open-computer-use/references/troubleshooting.md`

--- a/skills/open-computer-use/SKILL.md
+++ b/skills/open-computer-use/SKILL.md
@@ -9,22 +9,25 @@ description: Platform-neutral guidance for using Open Computer Use, the open-sou
 
 Open Computer Use exposes Computer Use as a local CLI and stdio MCP server. It is not Codex.app-specific; adapt the commands and MCP config to the agent runtime you are operating in.
 
+The macOS runtime requires macOS 14.0 or later. Windows and Linux use their own platform runtimes and are not subject to this macOS minimum.
+
 It supports the same core tool surface across macOS, Linux, and Windows:
 `list_apps`, `get_app_state`, `click`, `perform_secondary_action`, `scroll`,
 `drag`, `type_text`, `press_key`, and `set_value`.
 
 ## Core Workflow
 
-1. Check the CLI is installed with `open-computer-use -h` or `ocu -h`. If installation or setup is missing, read [references/installation.md](references/installation.md).
-2. On macOS, run `open-computer-use doctor` before the first real GUI task. If permissions are missing, ask the user to approve Accessibility and Screen Recording in the onboarding UI.
-3. Inspect available apps before acting: `open-computer-use call list_apps`.
-4. Capture current UI state with `open-computer-use call get_app_state --args '{"app":"TextEdit"}'`. The default state is usually enough for UI operation.
-5. When the task needs longer semantic text, such as chat history, email bodies, document text, or long form content, call `get_app_state` with `text_limit: 1000` or `text_limit: "max"`.
-6. When visible long pages or lists appear incomplete even after scrolling, call `get_app_state` with a larger `max_tree_nodes` or `max_tree_depth`.
-7. Prefer element-targeted actions using `element_index` from the latest `get_app_state` result.
-8. For multi-step CLI work, use `open-computer-use call --calls '<json-array>'` so one process can reuse the latest element index mapping.
-9. For agent runtimes that support local MCP servers, configure `open-computer-use mcp` or `ocu mcp` and call the exposed Computer Use tools directly. Read [references/usage.md](references/usage.md).
-10. If communication, permission, or desktop-session access fails, read [references/troubleshooting.md](references/troubleshooting.md).
+1. On macOS, run `sw_vers -productVersion` before invoking the CLI and require macOS 14.0 or later. On older versions, explain that the runtime cannot launch; do not recommend `doctor` or permission changes as a fix for binary incompatibility.
+2. Check the CLI is installed with `open-computer-use -h` or `ocu -h`. If installation or setup is missing, read [references/installation.md](references/installation.md).
+3. On supported macOS versions, run `open-computer-use doctor` before the first real GUI task. If permissions are missing, ask the user to approve Accessibility and Screen Recording in the onboarding UI.
+4. Inspect available apps before acting: `open-computer-use call list_apps`.
+5. Capture current UI state with `open-computer-use call get_app_state --args '{"app":"TextEdit"}'`. The default state is usually enough for UI operation.
+6. When the task needs longer semantic text, such as chat history, email bodies, document text, or long form content, call `get_app_state` with `text_limit: 1000` or `text_limit: "max"`.
+7. When visible long pages or lists appear incomplete even after scrolling, call `get_app_state` with a larger `max_tree_nodes` or `max_tree_depth`.
+8. Prefer element-targeted actions using `element_index` from the latest `get_app_state` result.
+9. For multi-step CLI work, use `open-computer-use call --calls '<json-array>'` so one process can reuse the latest element index mapping.
+10. For agent runtimes that support local MCP servers, configure `open-computer-use mcp` or `ocu mcp` and call the exposed Computer Use tools directly. Read [references/usage.md](references/usage.md).
+11. If communication, permission, or desktop-session access fails, read [references/troubleshooting.md](references/troubleshooting.md).
 
 ## Operating Rules
 

--- a/skills/open-computer-use/references/installation.md
+++ b/skills/open-computer-use/references/installation.md
@@ -2,6 +2,18 @@
 
 Read this reference when the user asks to install, verify, repair, or explain Open Computer Use setup.
 
+## Platform Requirements
+
+The macOS runtime requires macOS 14.0 or later. Windows and Linux use their own platform runtimes and are not subject to this macOS minimum.
+
+On macOS, verify the system version before attempting to run the CLI:
+
+```sh
+sw_vers -productVersion
+```
+
+On macOS versions earlier than 14.0, npm installation may succeed but the bundled binary cannot launch. `open-computer-use doctor` and changes to Accessibility or Screen Recording permissions cannot fix this binary incompatibility.
+
 ## Install The CLI
 
 Use npm:
@@ -28,7 +40,7 @@ npm update -g open-computer-use
 
 ## macOS Permissions
 
-macOS needs Accessibility and Screen Recording permissions before real app state and actions can work.
+On supported macOS versions, Accessibility and Screen Recording permissions are required before real app state and actions can work.
 
 Run:
 

--- a/skills/open-computer-use/references/troubleshooting.md
+++ b/skills/open-computer-use/references/troubleshooting.md
@@ -2,6 +2,16 @@
 
 Read this reference when setup, permission checks, app discovery, snapshots, or actions fail.
 
+## Unsupported macOS Version
+
+The macOS runtime requires macOS 14.0 or later. Check the host version before troubleshooting permissions:
+
+```sh
+sw_vers -productVersion
+```
+
+On macOS versions earlier than 14.0, the binary cannot launch and may report a `dyld` or minimum-version incompatibility. `open-computer-use doctor`, Accessibility authorization, and Screen Recording authorization cannot resolve this error. Upgrade macOS or run Open Computer Use on a supported macOS, Windows, or Linux desktop.
+
 ## First Checks
 
 Start with:
@@ -12,7 +22,7 @@ open-computer-use doctor
 open-computer-use call list_apps
 ```
 
-On macOS, `doctor` reports Accessibility and Screen Recording status. If either is missing, ask the user to approve the onboarding UI.
+On macOS 14.0 or later, `doctor` reports Accessibility and Screen Recording status. If either is missing, ask the user to approve the onboarding UI.
 
 ## App Not Found
 


### PR DESCRIPTION
macOS 运行时要求 14.0 或更高版本，但安装和排障入口此前没有明确区分系统兼容性与权限问题。

在中英文 README 以及 open-computer-use skill 的入口、安装和排障文档中补充最低版本说明。要求 Agent 在执行 doctor 前先检查系统版本，并明确低版本二进制不兼容无法通过授权修复。

这能避免低版本用户被错误引导到 Accessibility 和 Screen Recording 权限流程，同时不改变 CLI、MCP 接口或其他平台行为。

----------------------------------------------------------------------

docs(macos): document macOS 14.0 minimum requirement

The macOS runtime requires version 14.0 or later, but the installation and troubleshooting entry points did not clearly separate system compatibility from permission issues.

Document the minimum version in both READMEs and in the open-computer-use skill entry, installation, and troubleshooting guidance. Require agents to check the system version before running doctor and explain that permissions cannot fix an incompatible binary.

This keeps users on older macOS versions from being sent through Accessibility and Screen Recording troubleshooting while leaving the CLI, MCP interface, and other platform behavior unchanged.