### PR TITLE
fix(agent): isolate namespaced app sockets

### DIFF
--- a/apps/OpenComputerUse/Sources/OpenComputerUse/MacOSAppAgentProxy.swift
+++ b/apps/OpenComputerUse/Sources/OpenComputerUse/MacOSAppAgentProxy.swift
@@ -67,7 +67,11 @@ enum MacOSAppAgentProxy {
 
     private static func defaultSocketPath() -> String {
         FileManager.default.temporaryDirectory
-            .appendingPathComponent("open-computer-use-agent.sock")
+            .appendingPathComponent(
+                openComputerUseAppAgentSocketFileName(
+                    namespace: ProcessInfo.processInfo.environment[openComputerUseAppAgentSocketNamespaceEnvironmentKey]
+                )
+            )
             .standardizedFileURL
             .path
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,7 +39,7 @@
 
 - `OpenComputerUse` 默认 app 模式会拉起 `PermissionOnboardingApp`。
 - app bundle 以 `LSUIElement` agent-style 形态运行，默认不在 Dock 暴露常驻图标，但仍可按需显示权限窗口。
-- 当用户从终端执行 macOS 版 `open-computer-use mcp`、`doctor`、`call`、`snapshot` 或 `list-apps` 时，CLI 会先通过 LaunchServices 启动同一个 `.app` bundle 的隐藏 app agent，并通过用户临时目录下的 Unix domain socket 转发请求；真正调用 Accessibility、ScreenCaptureKit 和动作 tools 的进程始终是 `Open Computer Use.app`，不是 iTerm / Terminal / Node launcher。
+- 当用户从终端执行 macOS 版 `open-computer-use mcp`、`doctor`、`call`、`snapshot` 或 `list-apps` 时，CLI 会先通过 LaunchServices 启动同一个 `.app` bundle 的隐藏 app agent，并通过用户临时目录下的 Unix domain socket 转发请求；真正调用 Accessibility、ScreenCaptureKit 和动作 tools 的进程始终是 `Open Computer Use.app`，不是 iTerm / Terminal / Node launcher。默认 Socket 文件名保持历史兼容；嵌入式宿主可设置 `OPEN_COMPUTER_USE_AGENT_SOCKET_NAMESPACE`，使其使用 namespace 摘要对应的私有 Socket，避免与其他 OCU bundle 共用 Agent。
 - CLI 与 MCP proxy 会把调用进程中 `OPEN_COMPUTER_USE_*` 前缀的环境变量随请求转发给 app agent，并只在该请求执行期间临时覆盖 agent 环境；这让 `click_method=global` 的进程级安全门和 debug 开关在 app-agent 架构下仍按调用方配置生效。
 - 主窗口负责渲染 `Accessibility` / `Screen & System Audio Recording` 两类权限卡片、`Allow` / `Done` 状态和 relaunch 后的状态收敛；当两项权限都已完成时会自动关闭，不再要求用户手动退出。
 - 辅助 drag panel 会跳转到对应的 `System Settings` 页面；点击 `Allow` 后，panel 会从主窗口里的按钮位置做一段 spring + curved frame 的入场，再落到 `System Settings` 内容区下沿。panel 默认保持在窗口右侧内容区下方居中并固定贴近窗口底边，不再依赖实时扫描权限页内部 `+ / -` 控件行；窗口层级上会显式排在当前 `System Settings` 窗口之上，避免被权限列表内容盖住，同时尽量减少对系统设置自身滚动区域的干扰。panel 内也补了显式返回按钮，允许用户中断当前 guidance、回到 onboarding 主窗口重新选择权限步骤。

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## 当前实现边界
 
-- 对 MCP host 暴露的接口仍是本地 `stdio`；macOS CLI 与 `.app` app agent 之间会使用用户临时目录下的 Unix domain socket，socket 创建后会收紧为当前用户读写，且不对外监听 TCP/HTTP 端口。
+- 对 MCP host 暴露的接口仍是本地 `stdio`；macOS CLI 与 `.app` app agent 之间会使用用户临时目录下的 Unix domain socket，socket 创建后会收紧为当前用户读写，且不对外监听 TCP/HTTP 端口。未设置 `OPEN_COMPUTER_USE_AGENT_SOCKET_NAMESPACE` 时继续使用历史 Socket；设置后仅以 namespace 摘要派生私有文件名，不把宿主目录或原始 namespace 写入 Socket 路径。
 - 所有动作都必须显式带 `app` 参数；当前不会在后台自动扫描并控制任意 app。
 - macOS 真实 app 路径依赖 `Open Computer Use.app` 已获得 `Accessibility` 与 `Screen Recording` 权限；终端里的 CLI / Node launcher 会把 `mcp`、`doctor`、`call`、`snapshot` 和 `list-apps` 转发给由 LaunchServices 启动的本地 app agent，避免把权限要求落到 iTerm / Terminal 身上。
 - 实验性 Linux runtime 依赖已登录桌面用户的 AT-SPI2 / D-Bus session；coordinate mouse、drag、keyboard synthesis 只是 best-effort fallback，不应被视为跨 Wayland compositor 的通用后台输入授权。

--- a/docs/exec-plans/active/20260901-embedded-app-agent-socket-isolation.md
+++ b/docs/exec-plans/active/20260901-embedded-app-agent-socket-isolation.md
@@ -1,0 +1,46 @@
+# 隔离嵌入式宿主的 macOS App Agent Socket
+
+## 目标
+
+为 Open Computer Use 的 macOS App Agent 增加一个可选的、确定性的 Socket namespace。未配置 namespace 的所有既有调用继续使用历史 Socket 路径；配置 namespace 的嵌入式宿主使用私有 Socket，避免不同 OCU bundle 互相终止 App Agent。
+
+## 范围
+
+- 包含：Socket 文件名解析、默认兼容行为、单元测试、版本发布前的构建验证和历史记录。
+- 不包含：修改或停止用户全局/NVM OCU、改变 App Agent 权限模型、重试非幂等页面动作。
+
+## 背景
+
+- 相关文档：`docs/ARCHITECTURE.md`、`docs/REPO_COLLAB_GUIDE.md`、`docs/HISTORY_GUIDE.md`。
+- 相关代码路径：`apps/OpenComputerUse/Sources/OpenComputerUse/MacOSAppAgentProxy.swift`、`packages/OpenComputerUseKit`。
+- 已知约束：历史版本固定使用 `open-computer-use-agent.sock`；当两个不同 bundle 使用该 Socket 时，后启动者会终止先启动的 Agent。Boss 筛简历必须使用内置 OCU，不能依赖或干扰全局 OCU。
+
+## 风险
+
+- 风险：更改默认路径会破坏已有 CLI/MCP 调用。
+- 缓解方式：namespace 未设置或为空时严格返回历史文件名；仅对显式 namespace 使用新的短哈希文件名。
+- 风险：Socket 路径过长或泄露宿主数据目录。
+- 缓解方式：只使用 SHA-256 摘要的前 16 位，不把原 namespace 写入文件名或诊断。
+
+## 里程碑
+
+1. 确认 Socket 冲突路径和向后兼容边界。
+2. 实现可选 namespace 并覆盖默认、确定性和隔离性测试。
+3. 构建、记录历史，并等待获准发布新的运行时版本后供嵌入式宿主升级。
+
+## 验证方式
+
+- 命令：`swift test --filter OpenComputerUseKitTests/testAppAgentSocketFileName`。
+- 命令：`swift build --product OpenComputerUse`。
+- 手工检查：未设置环境变量时文件名仍是 `open-computer-use-agent.sock`。
+- 观测检查：两个不同 namespace 对应不同 Socket 文件名；不会对历史 Socket 执行 terminate/unlink。
+
+## 进度记录
+
+- [x] 确认固定全局 Socket 是跨 bundle 互相终止 Agent 的根因。
+- [x] 完成 namespace 解析与单元测试。
+- [x] 完成构建验证和历史记录；本地提交后等待获准发布新运行时，嵌入式宿主才能升级。
+
+## 决策记录
+
+- 2026-09-01：采用 opt-in namespace，而不是修改全局默认路径或禁用 App Agent 代理，以保留旧调用的兼容性并隔离嵌入式宿主。

--- a/docs/histories/2026-09/20260901-1020-isolate-app-agent-socket.md
+++ b/docs/histories/2026-09/20260901-1020-isolate-app-agent-socket.md
@@ -1,0 +1,31 @@
+## [2026-09-01 10:20] | Task: 隔离嵌入式 App Agent Socket
+
+### 🤖 Execution Context
+* **Agent ID**: `Codex desktop`
+* **Base Model**: `GPT-5`
+* **Runtime**: `macOS arm64`
+
+### 📥 User Query
+> 修复 Electron 内置 OCU 在运行期间被其他 OCU App Agent Socket 争用而导致页面动作连接关闭的问题；不得影响用户的全局 OCU。
+
+### 🛠 Changes Overview
+**Scope:** macOS App Agent proxy、Socket path contract、单元测试和架构/安全文档。
+
+**Key Actions:**
+- **[Optional namespace]**: 增加 `OPEN_COMPUTER_USE_AGENT_SOCKET_NAMESPACE`。未设置或为空时严格沿用 `open-computer-use-agent.sock`。
+- **[Private socket]**: 设置 namespace 时，以 SHA-256 摘要前 16 个十六进制字符派生短 Socket 文件名，不泄露原值。
+- **[Verification]**: 单元测试覆盖默认兼容、确定性和 namespace 间隔离；构建 `OpenComputerUse` 成功。
+
+### 🧠 Design Intent (Why)
+不同 OCU bundle 过去共享一个固定 Socket；当一个 bundle 发现 Socket 中的 Agent 来自另一个 bundle 时会终止它。可选 namespace 让嵌入式宿主独占自己的 Agent，而不改变未配置 namespace 的现有 CLI、MCP 或全局安装行为。
+
+### ✅ Verification
+- `swift test --filter OpenComputerUseKitTests/testAppAgentSocketFileName`：2 tests passed。
+- `swift build --product OpenComputerUse`：passed；仅有既存的 `nonisolated(unsafe)` warning。
+
+### 📁 Files Modified
+- `apps/OpenComputerUse/Sources/OpenComputerUse/MacOSAppAgentProxy.swift`
+- `packages/OpenComputerUseKit/Sources/OpenComputerUseKit/AppAgentSocketNamespace.swift`
+- `packages/OpenComputerUseKit/Tests/OpenComputerUseKitTests/OpenComputerUseKitTests.swift`
+- `docs/ARCHITECTURE.md`
+- `docs/SECURITY.md`

--- a/packages/OpenComputerUseKit/Sources/OpenComputerUseKit/AppAgentSocketNamespace.swift
+++ b/packages/OpenComputerUseKit/Sources/OpenComputerUseKit/AppAgentSocketNamespace.swift
@@ -1,0 +1,14 @@
+import CryptoKit
+import Foundation
+
+public let openComputerUseAppAgentSocketNamespaceEnvironmentKey = "OPEN_COMPUTER_USE_AGENT_SOCKET_NAMESPACE"
+
+public func openComputerUseAppAgentSocketFileName(namespace: String?) -> String {
+    guard let namespace = namespace?.trimmingCharacters(in: .whitespacesAndNewlines), !namespace.isEmpty else {
+        return "open-computer-use-agent.sock"
+    }
+
+    let digest = SHA256.hash(data: Data(namespace.utf8))
+    let identifier = digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+    return "open-computer-use-agent-\(identifier).sock"
+}

--- a/packages/OpenComputerUseKit/Tests/OpenComputerUseKitTests/OpenComputerUseKitTests.swift
+++ b/packages/OpenComputerUseKit/Tests/OpenComputerUseKitTests/OpenComputerUseKitTests.swift
@@ -4,6 +4,22 @@ import XCTest
 @testable import OpenComputerUseKit
 
 final class OpenComputerUseKitTests: XCTestCase {
+    func testAppAgentSocketFileNamePreservesLegacyDefault() {
+        XCTAssertEqual(openComputerUseAppAgentSocketFileName(namespace: nil), "open-computer-use-agent.sock")
+        XCTAssertEqual(openComputerUseAppAgentSocketFileName(namespace: "   "), "open-computer-use-agent.sock")
+    }
+
+    func testAppAgentSocketFileNameIsDeterministicAndNamespaced() {
+        let first = openComputerUseAppAgentSocketFileName(namespace: "boss-resume:profile-a")
+        let second = openComputerUseAppAgentSocketFileName(namespace: "boss-resume:profile-b")
+
+        XCTAssertEqual(first, openComputerUseAppAgentSocketFileName(namespace: "boss-resume:profile-a"))
+        XCTAssertNotEqual(first, second)
+        XCTAssertTrue(first.hasPrefix("open-computer-use-agent-"))
+        XCTAssertTrue(first.hasSuffix(".sock"))
+        XCTAssertLessThan(first.count, 80)
+    }
+
     func testCLIRecognizesGlobalHelpAndVersionFlags() throws {
         XCTAssertEqual(try parseOpenComputerUseCLI(arguments: ["-h"]), .help(command: nil))
         XCTAssertEqual(try parseOpenComputerUseCLI(arguments: ["--help"]), .help(command: nil))


### PR DESCRIPTION
为内嵌宿主提供确定性的 App Agent Socket 命名空间；
未配置时保持旧 Socket 兼容，避免不同 OCU bundle 因共享 Socket 相互终止或替换 Agent。